### PR TITLE
fix(database): change logging and add timezone

### DIFF
--- a/Serverapp/Configuration/Database.js
+++ b/Serverapp/Configuration/Database.js
@@ -3,7 +3,8 @@ import { Sequelize } from "sequelize";
 const db = new Sequelize("db_MANAGEMENT_BUDGET_SYSTEM", "root", "", {
   host: "localhost",
   dialect: "mysql",
-  logging: console.log(),
+  logging: console.log,
+  timezone: "+07:00",
 });
 
 export default db;


### PR DESCRIPTION
change logging cause when we execute a api, ORM will type sql syntax on CLI
timezone is for when we use create specific table used CURRENT_TIMESTAMP it will use a timezone indonesia. not global